### PR TITLE
A simple fix for slow CSV searching

### DIFF
--- a/barcoderattler.py
+++ b/barcoderattler.py
@@ -82,15 +82,12 @@ def mms(rr):
       print(e)
       return False
 
-def findRow(code):
-   with open(MMSCSV, 'r') as read_obj:
-      csv_dict_reader = DictReader(read_obj)
-      for row in csv_dict_reader:
-         if row['BARCODE'] == code:
-            return row
-
 try:
    lastData=''
+   codes={}
+   with open(MMSCSV, 'r') as read_obj:
+      csv_dict_reader = DictReader(read_obj)
+      codes = {row['BARCODE']: row for row in csv_dict_reader}
    while True:
       data = readBarcode()
       if data:
@@ -98,7 +95,7 @@ try:
             GPIO.output(led, GPIO.HIGH)
             lastData = data
             print(lastData)
-            rr=findRow(data)
+            rr=codes[data]
             if rr:
                print(rr['CORE'], rr['FILE'])
                if mms(rr) == False:


### PR DESCRIPTION
I noticed in Neil's demo on YT that the time between scanning seemed to be pretty slow and highly variable. After he mentioned the barcodes were being stored in CSV, I rightly assumed that the CSV was being parsed and searched through every time a code is scanned. This is super inefficient, and only provides one small advantage in that simply uploading a new csv will immediately make new titles available to scan.

This PR switches things around to only load the CSV once when the script loads, and then does a list comprehension on it to build an index by barcode.  I haven't tested it (I don't have a barcode scanner), but it should allow for lightning fast lookups.  There are only three caveats to this approach:

1) All of the barcodes and other data in the CSV will be stored in memory.  As long as the number of columns in the CSV doesn't get ridiculous, I can't see this being an actual problem on a RPi.

2) Each row in the CSV will need a unique barcode. Really, this was already the case as the current script will only ever return the data for the first barcode it finds. After this change, if there are duplicates I believe you'd only get the data for the LAST duplicate in the file.

3) The script will need to be restarted whenever the CSV is updated.

**EDIT:**  I didn't notice a script had also been added for NFCs. The same change could easily be made to that script as well.